### PR TITLE
Hotfix: infinite loop on critical error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 obj
 Properties
+*.json

--- a/Code2Gether-Discord-Bot/Bot.cs
+++ b/Code2Gether-Discord-Bot/Bot.cs
@@ -16,15 +16,15 @@ namespace Code2Gether_Discord_Bot
     public class Bot : IBot
     {
         private ILogger _logger;
+        private IConfig _config;
         private DiscordSocketClient _client;
         private CommandService _commands;
         private IServiceProvider _services;
 
-        private readonly string _prefix = Environment.GetEnvironmentVariable("prefix");
-
-        public Bot(ILogger logger)
+        public Bot(ILogger logger, IConfig config)
         {
             _logger = logger;
+            _config = config;
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Code2Gether_Discord_Bot
         /// <returns></returns>
         private async Task InitialStartupJobs()
         {
-            await _client.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("token"));
+            await _client.LoginAsync(TokenType.Bot, _config.DiscordToken);
             await _client.StartAsync();
         }
 
@@ -115,7 +115,7 @@ namespace Code2Gether_Discord_Bot
         private Task ReadyHandler()
         {
             // Set bot status
-            string status = $"{_prefix}help";
+            string status = $"{_config.Prefix}help";
             return _client.SetGameAsync(status);
         }
 
@@ -168,7 +168,7 @@ namespace Code2Gether_Discord_Bot
 
             // If msg has this bot's prefix
             int argPos = 0;
-            if (!(msg.HasStringPrefix(_prefix.ToLower(), ref argPos) || msg.HasStringPrefix(_prefix.ToUpper(), ref argPos))) return;
+            if (!(msg.HasStringPrefix(_config.Prefix.ToLower(), ref argPos) || msg.HasStringPrefix(_config.Prefix.ToUpper(), ref argPos))) return;
 
             var result = await _commands.ExecuteAsync(context, argPos, _services);
             if (result.Error.HasValue) _logger.Log(LogSeverity.Debug, $"Message: {msg} returned: {result.Error.Value}");

--- a/Code2Gether-Discord-Bot/Code2Gether-Discord-Bot.csproj
+++ b/Code2Gether-Discord-Bot/Code2Gether-Discord-Bot.csproj
@@ -15,4 +15,13 @@
     <ProjectReference Include="..\Code2Gether-Discord-Bot.Library\Code2Gether-Discord-Bot.Library.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Properties\launchSettings.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Code2Gether-Discord-Bot/Models/Config.cs
+++ b/Code2Gether-Discord-Bot/Models/Config.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace Code2Gether_Discord_Bot.Models
+{
+    public interface IConfig
+    {
+        string DiscordToken { get; set; }
+        string Prefix { get; set; }
+    }
+
+    public class Config : IConfig
+    {
+        [JsonProperty("prefix")]
+        public string Prefix { get; set; }
+
+        [JsonProperty("token")]
+        public string DiscordToken { get; set; }
+
+        public Config() { }
+
+        public Config(string prefix, string token)
+        {
+            Prefix = prefix;
+            DiscordToken = token;
+        }
+    }
+}

--- a/Code2Gether-Discord-Bot/Program.cs
+++ b/Code2Gether-Discord-Bot/Program.cs
@@ -13,16 +13,13 @@ namespace Code2Gether_Discord_Bot
             ILogger logger = UtilityFactory.GetLogger();
             IBot bot = UtilityFactory.GetBot();
 
-            while (true)
+            try
             {
-                try
-                {
-                    bot.RunAsync().GetAwaiter().GetResult();
-                }
-                catch (Exception e)
-                {
-                    logger.Log(LogSeverity.Critical, $"Main process terminated! Exception: {e.Message}");
-                }
+                bot.RunAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogSeverity.Critical, $"Main process terminated! Exception: {e.Message}");
             }
         }
     }

--- a/Code2Gether-Discord-Bot/Static/ConfigProvider.cs
+++ b/Code2Gether-Discord-Bot/Static/ConfigProvider.cs
@@ -1,0 +1,34 @@
+﻿using Code2Gether_Discord_Bot.Models;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace Code2Gether_Discord_Bot.Static
+{
+    public static class ConfigProvider
+    {
+        private static FileInfo configFile = new FileInfo("config.json");
+        public static IConfig GetConfig()
+        {
+            IConfig config = new Config("c!", "PLACEHOLDER"); ;
+            try
+            {
+                config = JsonConvert.DeserializeObject<Config>(File.ReadAllText(configFile.FullName));
+            }
+            catch (Exception e)
+            {
+                GenerateNewConfig(config);
+            }
+
+            return config;
+        }
+
+        private static void GenerateNewConfig(IConfig config)
+        {
+            var configJson = JsonConvert.SerializeObject(config);
+            configFile.Delete();
+            File.WriteAllText(configFile.FullName, configJson);
+            configFile = new FileInfo(configFile.FullName);
+        }
+    }
+}

--- a/Code2Gether-Discord-Bot/Static/UtilityFactory.cs
+++ b/Code2Gether-Discord-Bot/Static/UtilityFactory.cs
@@ -10,6 +10,7 @@ namespace Code2Gether_Discord_Bot.Static
     public static class UtilityFactory
     {
         public static ILogger GetLogger() => new Logger();
-        public static IBot GetBot() => new Bot(GetLogger());
+        public static IBot GetBot() => new Bot(GetLogger(), GetConfig());
+        public static IConfig GetConfig() => ConfigProvider.GetConfig();
     }
 }


### PR DESCRIPTION
For instance, if the token is invalid, the program should crash. Instead it loops infinitely.