### PR TITLE
HOTFIX - Broke help output into multiple fields

### DIFF
--- a/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
+++ b/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
@@ -3,6 +3,7 @@ using Discord;
 using Discord.Commands;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading.Tasks;
 using Serilog;
@@ -22,33 +23,53 @@ namespace Code2Gether_Discord_Bot.Library.BusinessLogic
 
         public override Task<Embed> ExecuteAsync()
         {
-            var embed = new EmbedBuilder()
-                .WithColor(Color.Purple)
-                .WithTitle("Help")
-                .WithDescription($"Contains information on how to access this bot's command modules")
-                .AddField("Commands", GetCommandText())
-                .WithAuthor(_context.Message.Author)
-                .Build();
+            try
+            {
+                var commandText = GetCommandText();
 
-            return Task.FromResult(embed);
+                var embedBuilder = new EmbedBuilder()
+                    .WithColor(Color.Purple)
+                    .WithTitle("Help")
+                    .WithDescription("Contains information on how to access this bot's command modules")
+                    .WithAuthor(_context.Message.Author);
+
+                for (var i = 0; i < commandText.Length; i++)
+                {
+                    embedBuilder.AddField($"Command {i + 1} of {commandText.Length}", commandText[i]);
+                }
+
+                var embed = embedBuilder.Build();
+
+                return Task.FromResult(embed);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
         }
 
-        private string GetCommandText()
+        private string[] GetCommandText()
         {
-            var commandTextSb = new StringBuilder();
+            var commandTexts = new List<string>();
+
             foreach (var module in _modules)
             {
+                var moduleStringBuilder = new StringBuilder();
+
                 foreach (var command in module.Commands)
                 {
                     var aliasesSb = new StringBuilder();
                     foreach (var alias in command.Aliases)
                     {
-                        aliasesSb.Append($"{alias};");
+                        aliasesSb.Append(alias);
                     }
-                    commandTextSb.Append($"{_prefix}{command.Name} ({aliasesSb}) - {command.Summary}{Environment.NewLine}");
+                    moduleStringBuilder.Append($"{_prefix}{command.Name} ({aliasesSb}) - {command.Summary}{Environment.NewLine}");
                 }
+
+                commandTexts.Add(moduleStringBuilder.ToString());
             }
-            return commandTextSb.ToString();
+            return commandTexts.ToArray();
         }
     }
 }

--- a/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
+++ b/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
@@ -1,9 +1,7 @@
-﻿using Code2Gether_Discord_Bot.Library.Models;
-using Discord;
+﻿using Discord;
 using Discord.Commands;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading.Tasks;
 using Serilog;

--- a/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
+++ b/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
@@ -23,33 +23,25 @@ namespace Code2Gether_Discord_Bot.Library.BusinessLogic
 
         public override Task<Embed> ExecuteAsync()
         {
-            try
+            var commandText = GetCommandText();
+
+            var embedBuilder = new EmbedBuilder()
+                .WithColor(Color.Purple)
+                .WithTitle("Help")
+                .WithDescription("Contains information on how to access this bot's command modules")
+                .WithAuthor(_context.Message.Author);
+
+            for (var i = 0; i < commandText.Count; i++)
             {
-                var commandText = GetCommandText();
-
-                var embedBuilder = new EmbedBuilder()
-                    .WithColor(Color.Purple)
-                    .WithTitle("Help")
-                    .WithDescription("Contains information on how to access this bot's command modules")
-                    .WithAuthor(_context.Message.Author);
-
-                for (var i = 0; i < commandText.Length; i++)
-                {
-                    embedBuilder.AddField($"Command {i + 1} of {commandText.Length}", commandText[i]);
-                }
-
-                var embed = embedBuilder.Build();
-
-                return Task.FromResult(embed);
+                embedBuilder.AddField($"Command {i + 1} of {commandText.Count}", commandText[i]);
             }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                throw;
-            }
+
+            var embed = embedBuilder.Build();
+
+            return Task.FromResult(embed);
         }
 
-        private string[] GetCommandText()
+        private List<string> GetCommandText()
         {
             var commandTexts = new List<string>();
 
@@ -69,7 +61,7 @@ namespace Code2Gether_Discord_Bot.Library.BusinessLogic
 
                 commandTexts.Add(moduleStringBuilder.ToString());
             }
-            return commandTexts.ToArray();
+            return commandTexts;
         }
     }
 }

--- a/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
+++ b/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
@@ -49,12 +49,14 @@ namespace Code2Gether_Discord_Bot.Library.BusinessLogic
 
                 foreach (var command in module.Commands)
                 {
-                    var aliasesSb = new StringBuilder();
+                    var commandAliasStringBuilder = new StringBuilder();
+
                     foreach (var alias in command.Aliases)
                     {
-                        aliasesSb.Append(alias);
+                        commandAliasStringBuilder.Append(alias);
                     }
-                    moduleStringBuilder.Append($"{_prefix}{command.Name} ({aliasesSb}) - {command.Summary}{Environment.NewLine}");
+
+                    moduleStringBuilder.Append($"{_prefix}{command.Name} ({commandAliasStringBuilder}) - {command.Summary}{Environment.NewLine}");
                 }
 
                 commandTexts.Add(moduleStringBuilder.ToString());

--- a/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
+++ b/Code2Gether-Discord-Bot.Library/BusinessLogic/HelpLogic.cs
@@ -10,8 +10,8 @@ namespace Code2Gether_Discord_Bot.Library.BusinessLogic
 {
     public class HelpLogic : BaseLogic
     {
-        private IEnumerable<ModuleInfo> _modules;
-        private string _prefix;
+        private readonly IEnumerable<ModuleInfo> _modules;
+        private readonly string _prefix;
 
         public HelpLogic(ILogger logger, ICommandContext context, IEnumerable<ModuleInfo> modules, string prefix) : base(logger, context)
         {


### PR DESCRIPTION
Fixed #53 

The issue was that a field can only contain 1024 characters. Fixed by spreading out to multiple fields.
As this is a hotfix, it will be doublechecked & approved by an admin.